### PR TITLE
Fix no_move flag condition in GMUI.gml

### DIFF
--- a/GMUI/scripts/GMUI/GMUI.gml
+++ b/GMUI/scripts/GMUI/GMUI.gml
@@ -843,7 +843,7 @@ function gmui_begin(name, x = 0, y = 0, w = 512, h = 256, flags = 0) {
     var window = gmui_get_window(name);
     if (!window) return false;
     
-    var no_move = (flags & gmui_window_flags.NO_MOVE) == 0;
+    var no_move = (flags & gmui_window_flags.NO_MOVE) != 0;
 	var no_border = (flags & gmui_window_flags.NO_BORDER) != 0;
 	var is_popup = (flags & gmui_window_flags.POPUP) != 0;
     


### PR DESCRIPTION
Fixed a bug where `no_move` was actually the inverse of what it was intended to be.

Now  produced intended behavior:
https://gyazo.com/5dd8e0c5796feb69d00735fb4636feb3.mp4