### PR TITLE
change gmui_input_float to not crash when typing "-."

### DIFF
--- a/GMUI/scripts/GMUI/GMUI.gml
+++ b/GMUI/scripts/GMUI/GMUI.gml
@@ -7106,7 +7106,7 @@ function gmui_input_float(value, step = 1, min_value = -1000000, max_value = 100
             global.gmui.active_textbox.changed = false;
             
             // Convert back to number if not empty
-            if (filtered_text != "" && filtered_text != "-" && filtered_text != ".") {
+            if (filtered_text != "" && filtered_text != "-" && filtered_text != "." && filtered_text != "-.") {
                 var new_num = real(filtered_text);
                 if (new_num != value) {
                     value = clamp(new_num, min_value, max_value);


### PR DESCRIPTION
it supports .1 so it should work with -.1 i guess, and on the current version it crashed when i tried doing that